### PR TITLE
Implement Pub/Sub-based embedding processing pipeline

### DIFF
--- a/functions/genkit/flows/embedChunkFlow.js
+++ b/functions/genkit/flows/embedChunkFlow.js
@@ -1,0 +1,23 @@
+import { z } from 'genkit';
+import { textEmbedding004 } from '@genkit-ai/vertexai';
+import { ai } from '../config.js';
+
+const embedChunkFlow = ai.defineFlow(
+  {
+    name: 'embedChunkFlow',
+    inputSchema: z.string(),
+    outputSchema: z.object({
+      embedding: z.array(z.number()),
+      model: z.string(),
+    }),
+  },
+  async (content) => {
+    const [res] = await ai.embed({
+      embedder: textEmbedding004,
+      content,
+    });
+    return { embedding: res.embedding, model: 'text-embedding-004' };
+  }
+);
+
+export default embedChunkFlow

--- a/functions/index.js
+++ b/functions/index.js
@@ -75,6 +75,7 @@ import {
 import productSuggestionFlow from './genkit/flows/productSuggestionFlow.js'
 import indexProductItemsFlow from './genkit/flows/indexProductItemsFlow.js'
 import ragProductQuestionFlow from './genkit/flows/ragProductQuestionFlow.js'
+import embedChunkFlow from './genkit/flows/embedChunkFlow.js'
 
 // TRIGGERS
 // ops
@@ -88,6 +89,9 @@ import queueHtmlDocument from './triggers/queueHtmlDocument.js';
 import processHtmlDocument from './triggers/processHtmlDocument.js';
 import queuePdfDocument from './triggers/queuePdfDocument.js';
 import processPdfDocument from './triggers/processPdfDocument.js';
+import { queueChunkEmbeddingOnCreate, queueChunkEmbeddingOnUpdate } from './triggers/queueChunkEmbeddings.js';
+import processChunkEmbedding from './triggers/processChunkEmbedding.js';
+import requeuePendingEmbeddings from './triggers/requeuePendingEmbeddings.js';
 // import extractChunksFromProductUrlsOnCreate from './triggers/extractChunksFromProductUrlsOnCreate.js';
 
 
@@ -328,5 +332,9 @@ export {
   processHtmlDocument,
   queuePdfDocument,
   processPdfDocument,
+  queueChunkEmbeddingOnCreate,
+  queueChunkEmbeddingOnUpdate,
+  processChunkEmbedding,
+  requeuePendingEmbeddings,
   // extractChunksFromProductUrlsOnCreate
 }

--- a/functions/triggers/processChunkEmbedding.js
+++ b/functions/triggers/processChunkEmbedding.js
@@ -1,0 +1,58 @@
+import { onMessagePublished } from 'firebase-functions/v2/pubsub';
+import admin from 'firebase-admin';
+import { db } from '../firebase/admin.js';
+import embedChunkFlow from '../genkit/flows/embedChunkFlow.js';
+// 🧠 Langsmith
+import { traceable } from 'langsmith/traceable';
+
+const processChunkEmbedding = onMessagePublished(
+  { topic: 'chunk-embeddings', region: 'us-central1' },
+  async (event) => {
+    const { docPath, hash } = event.data.message.json;
+    if (!docPath || !hash) return;
+
+    const tracedProcess = traceable(
+      async ({ docPath, hash }) => {
+        const docRef = db.doc(docPath);
+        const snapshot = await docRef.get();
+        if (!snapshot.exists) return;
+        const data = snapshot.data();
+        if (data.embeddingHash !== hash) return;
+
+        // Mark as processing with a lease
+        await docRef.update({
+          embeddingStatus: 'processing',
+          processingAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+
+        try {
+          const { embedding, model } = await embedChunkFlow(data.content);
+          await docRef.update({
+            embedding,
+            embeddingStatus: 'done',
+            embeddingModel: model,
+            errorMessage: null,
+          });
+        } catch (err) {
+          await docRef.update({
+            embeddingStatus: 'error',
+            errorMessage: err.message,
+            retries: admin.firestore.FieldValue.increment(1),
+          });
+        }
+      },
+      {
+        name: 'processChunkEmbedding',
+        run_type: 'tool',
+        extractInputs: (payload) => payload,
+        extractOutputs: () => ({}),
+        metadata: { docPath },
+        tags: ['process embedding'],
+      }
+    );
+
+    await tracedProcess({ docPath, hash });
+  }
+);
+
+export default processChunkEmbedding;

--- a/functions/triggers/processHtmlDocument.js
+++ b/functions/triggers/processHtmlDocument.js
@@ -5,6 +5,7 @@ import { onDocumentCreated } from "firebase-functions/v2/firestore";
 // utilities
 import { extractMeaningfulTextFromHtml } from '../utilities/externalDocs.js';
 import { splitTextWithLangChain } from '../utilities/textProcessing.js';
+import { computeHash } from '../utilities/hash.js';
 // 🧠 Langsmith
 import { traceable } from 'langsmith/traceable';
 
@@ -71,6 +72,10 @@ const processHtmlDocument = onDocumentCreated(
             content: chunkText,
             index,
             embeddingStatus: 'pending',
+            embeddingHash: computeHash(chunkText),
+            embeddingModel: null,
+            errorMessage: null,
+            retries: 0,
             sourceField: 'product_url',
             sourceIdentifier: `product/${productId}/product_url`,
             sourceType: 'html',

--- a/functions/triggers/processPdfDocument.js
+++ b/functions/triggers/processPdfDocument.js
@@ -5,6 +5,7 @@ import { onDocumentCreated } from "firebase-functions/v2/firestore";
 // utilities
 import { extractMeaningfulTextFromPdf } from '../utilities/externalDocs.js';
 import { splitTextWithLangChain } from '../utilities/textProcessing.js';
+import { computeHash } from '../utilities/hash.js';
 // 🧠 Langsmith
 import { traceable } from 'langsmith/traceable';
 
@@ -71,6 +72,10 @@ const processPdfDocument = onDocumentCreated(
             content: chunkText,
             index,
             embeddingStatus: 'pending',
+            embeddingHash: computeHash(chunkText),
+            embeddingModel: null,
+            errorMessage: null,
+            retries: 0,
             sourceField: 'pdf',
             sourceIdentifier: `product/${productId}/pdf_url`,
             sourceType: 'pdf',

--- a/functions/triggers/queueChunkEmbeddings.js
+++ b/functions/triggers/queueChunkEmbeddings.js
@@ -1,0 +1,58 @@
+import { onDocumentCreated, onDocumentUpdated } from 'firebase-functions/v2/firestore';
+import { PubSub } from '@google-cloud/pubsub';
+// 🧠 Langsmith
+import { traceable } from 'langsmith/traceable';
+
+const pubsub = new PubSub();
+const TOPIC = 'chunk-embeddings';
+
+const publish = (payload) =>
+  pubsub.topic(TOPIC).publishMessage({ json: payload });
+
+export const queueChunkEmbeddingOnCreate = onDocumentCreated(
+  'chunksEmbeddings/{chunkId}',
+  async (event) => {
+    const data = event.data?.data();
+    if (!data) return;
+
+    const docPath = event.data.ref.path;
+    const hash = data.embeddingHash;
+
+    const tracedPublish = traceable(publish, {
+      name: 'queueChunkEmbedding',
+      run_type: 'tool',
+      extractInputs: (payload) => payload,
+      extractOutputs: () => ({}),
+      metadata: { docPath },
+      tags: ['queue embedding'],
+    });
+
+    await tracedPublish({ docPath, hash });
+  }
+);
+
+export const queueChunkEmbeddingOnUpdate = onDocumentUpdated(
+  'chunksEmbeddings/{chunkId}',
+  async (event) => {
+    const before = event.data?.before;
+    const after = event.data?.after;
+    if (!before || !after) return;
+    const beforeField = before.get('sourceField');
+    const afterField = after.get('sourceField');
+    if (beforeField === afterField) return;
+
+    const docPath = after.ref.path;
+    const hash = after.get('embeddingHash');
+
+    const tracedPublish = traceable(publish, {
+      name: 'queueChunkEmbedding',
+      run_type: 'tool',
+      extractInputs: (payload) => payload,
+      extractOutputs: () => ({}),
+      metadata: { docPath },
+      tags: ['queue embedding'],
+    });
+
+    await tracedPublish({ docPath, hash });
+  }
+);

--- a/functions/triggers/requeuePendingEmbeddings.js
+++ b/functions/triggers/requeuePendingEmbeddings.js
@@ -1,0 +1,43 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { PubSub } from '@google-cloud/pubsub';
+import { db } from '../firebase/admin.js';
+// 🧠 Langsmith
+import { traceable } from 'langsmith/traceable';
+
+const pubsub = new PubSub();
+const TOPIC = 'chunk-embeddings';
+
+const requeuePendingEmbeddings = onSchedule(
+  { schedule: 'every 5 minutes', region: 'us-central1' },
+  async () => {
+    const tracedRequeue = traceable(
+      async () => {
+        const snap = await db
+          .collection('chunksEmbeddings')
+          .where('embeddingStatus', 'in', ['pending', 'error'])
+          .limit(200)
+          .get();
+
+        const promises = snap.docs.map((doc) =>
+          pubsub.topic(TOPIC).publishMessage({
+            json: { docPath: doc.ref.path, hash: doc.get('embeddingHash') }
+          })
+        );
+
+        await Promise.all(promises);
+        return { requeued: promises.length };
+      },
+      {
+        name: 'requeuePendingEmbeddings',
+        run_type: 'tool',
+        extractInputs: () => ({}),
+        extractOutputs: (output) => output,
+        tags: ['requeue embedding'],
+      }
+    );
+
+    await tracedRequeue();
+  }
+);
+
+export default requeuePendingEmbeddings;

--- a/functions/triggers/saveActiveParagraphAsChunk.js
+++ b/functions/triggers/saveActiveParagraphAsChunk.js
@@ -4,6 +4,7 @@ import admin from 'firebase-admin';
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
 // 🧠 Langsmith
 import { traceable } from 'langsmith/traceable';
+import { computeHash } from '../utilities/hash.js';
 
 
 // global
@@ -47,6 +48,10 @@ const saveActiveParagraphAsChunk = onDocumentCreated(
       embedding: null, // será llenado en el segundo trigger
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
       embeddingStatus: 'pending',
+      embeddingHash: computeHash(activeParagraph),
+      embeddingModel: null,
+      errorMessage: null,
+      retries: 0,
     });
 
     console.log(`Stored activeParagraph of product ${productId} as a chunk.`);

--- a/functions/utilities/hash.js
+++ b/functions/utilities/hash.js
@@ -1,0 +1,4 @@
+import crypto from 'crypto';
+
+export const computeHash = (text = '') =>
+  crypto.createHash('sha256').update(text, 'utf8').digest('hex');


### PR DESCRIPTION
## Summary
- hash chunk content and track embedding status and errors
- queue chunk documents for embedding via Pub/Sub
- process embedding jobs via Genkit flow and scheduled requeue of pending/error ones
- add Langsmith tracing for queue, processing, and requeue steps

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e3bcef7e88322b2f55bbd0669432f