### PR TITLE
feat(chat): add pubsub inbox queue

### DIFF
--- a/functions/handlers/chats/sendMessage.js
+++ b/functions/handlers/chats/sendMessage.js
@@ -1,0 +1,75 @@
+import { db } from '../../firebase/admin.js';
+import admin from 'firebase-admin';
+import { PubSub } from '@google-cloud/pubsub';
+
+const pubsub = new PubSub();
+const TOPIC = 'chat-messages';
+
+/**
+ * HTTP endpoint to enqueue a chat message.
+ * Expects auth middleware to populate req.user.uid.
+ * Body: { userQuery: string, sessionId?: string, clientMsgId?: string }
+ */
+const sendMessage = async (req, res) => {
+  try {
+    const userId = req.user && req.user.uid;
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const { userQuery, sessionId: providedSessionId, clientMsgId } = req.body || {};
+    if (!userQuery) {
+      res.status(400).json({ error: 'userQuery required' });
+      return;
+    }
+
+    // Ensure session exists
+    let sessionId = providedSessionId;
+    let sessionRef;
+    if (!sessionId) {
+      sessionRef = db.collection('chats').doc(userId).collection('sessions').doc();
+      sessionId = sessionRef.id;
+      await sessionRef.set({
+        created_at: admin.firestore.FieldValue.serverTimestamp(),
+        last_message_at: admin.firestore.FieldValue.serverTimestamp(),
+        message_count: 0,
+      });
+    } else {
+      sessionRef = db.collection('chats').doc(userId).collection('sessions').doc(sessionId);
+      await sessionRef.set({
+        last_message_at: admin.firestore.FieldValue.serverTimestamp(),
+      }, { merge: true });
+    }
+
+    // Store user message
+    const messageRef = await sessionRef.collection('messages').add({
+      role: 'user',
+      content: userQuery,
+      created_at: admin.firestore.FieldValue.serverTimestamp(),
+      status: 'received',
+      client_msg_id: clientMsgId || null,
+    });
+
+    const payload = {
+      docPath: messageRef.path,
+      userId,
+      sessionId,
+      messageId: messageRef.id,
+      client_msg_id: clientMsgId || null,
+    };
+
+    await pubsub.topic(TOPIC).publishMessage({ json: payload });
+
+    await sessionRef.set({
+      message_count: admin.firestore.FieldValue.increment(1),
+    }, { merge: true });
+
+    res.json({ sessionId, messageId: messageRef.id });
+  } catch (err) {
+    console.error('sendMessage error', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+export { sendMessage };

--- a/functions/index.js
+++ b/functions/index.js
@@ -59,6 +59,7 @@ import {
   chatsNlpApiForDocs,
   chatsNlpApiForComposeDescription,
 } from './handlers/chats/chats.js';
+import { sendMessage } from './handlers/chats/sendMessage.js';
 
 // whatsapp
 import {
@@ -92,6 +93,8 @@ import processPdfDocument from './triggers/processPdfDocument.js';
 import { queueChunkEmbeddingOnCreate, queueChunkEmbeddingOnUpdate } from './triggers/queueChunkEmbeddings.js';
 import processChunkEmbedding from './triggers/processChunkEmbedding.js';
 import requeuePendingEmbeddings from './triggers/requeuePendingEmbeddings.js';
+import processChatMessage from './triggers/processChatMessage.js';
+import requeueStuckChatMessages from './triggers/requeueStuckChatMessages.js';
 // import extractChunksFromProductUrlsOnCreate from './triggers/extractChunksFromProductUrlsOnCreate.js';
 
 
@@ -265,6 +268,7 @@ app.post(`/${apiVersion}/queries2`, firebaseAuth, queriesOpenAIAndAlgolia);
 // // user admin
 // // 3-POST /chats: Crea un nuevo chat para interactuar con llm.
 app.post(`/${apiVersion}/chats`, firebaseAuth, chatsOnlyLLM);
+app.post(`/${apiVersion}/chats/sendMessage`, firebaseAuth, sendMessage);
 // // 3a-POST /chats-nlp-api: Crea un nuevo chat para interactuar con api nlp.
 app.post(`/${apiVersion}/chats-nlp-api-docs`, firebaseAuth, chatsNlpApiForDocs);
 // // 3b-POST /chats-nlp-api: Crea un nuevo chat para interactuar con api nlp.
@@ -336,5 +340,7 @@ export {
   queueChunkEmbeddingOnUpdate,
   processChunkEmbedding,
   requeuePendingEmbeddings,
+  processChatMessage,
+  requeueStuckChatMessages,
   // extractChunksFromProductUrlsOnCreate
 }

--- a/functions/triggers/processChatMessage.js
+++ b/functions/triggers/processChatMessage.js
@@ -1,0 +1,57 @@
+import { onMessagePublished } from 'firebase-functions/v2/pubsub';
+import { db } from '../firebase/admin.js';
+import admin from 'firebase-admin';
+
+const processChatMessage = onMessagePublished('chat-messages', async (event) => {
+  const payload = event.data.message.json || {};
+  const { docPath, userId, sessionId } = payload;
+  const workerId = event.id;
+
+  const sessionRef = db.collection('chats').doc(userId).collection('sessions').doc(sessionId);
+  const messageRef = db.doc(docPath);
+
+  try {
+    await db.runTransaction(async (tx) => {
+      const sessionSnap = await tx.get(sessionRef);
+      const lock = sessionSnap.get('lock');
+      const now = Date.now();
+      const leaseUntil = lock && lock.lease_until && lock.lease_until.toMillis ? lock.lease_until.toMillis() : 0;
+      if (leaseUntil > now) {
+        throw new Error('locked');
+      }
+      tx.set(sessionRef, {
+        lock: {
+          leased_by: workerId,
+          lease_until: admin.firestore.Timestamp.fromMillis(now + 60000)
+        }
+      }, { merge: true });
+    });
+
+    await messageRef.update({ status: 'processing' });
+
+    const assistantRef = sessionRef.collection('messages').doc();
+    await assistantRef.set({
+      role: 'assistant',
+      content: 'Mensaje procesado.',
+      created_at: admin.firestore.FieldValue.serverTimestamp(),
+      status: 'done'
+    });
+
+    await messageRef.update({ status: 'done' });
+
+    await sessionRef.set({
+      lock: admin.firestore.FieldValue.delete(),
+      last_message_at: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+
+  } catch (err) {
+    console.error('processChatMessage error', err.message);
+    await messageRef.set({
+      status: 'error',
+      error_message: err.message
+    }, { merge: true });
+    throw err; // make pub/sub retry
+  }
+});
+
+export default processChatMessage;

--- a/functions/triggers/requeueStuckChatMessages.js
+++ b/functions/triggers/requeueStuckChatMessages.js
@@ -1,0 +1,36 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { PubSub } from '@google-cloud/pubsub';
+import { db } from '../firebase/admin.js';
+import admin from 'firebase-admin';
+
+const pubsub = new PubSub();
+const TOPIC = 'chat-messages';
+
+const requeueStuckChatMessages = onSchedule({
+  schedule: 'every 5 minutes',
+  region: 'us-central1'
+}, async () => {
+  const cutoff = admin.firestore.Timestamp.fromMillis(Date.now() - 5 * 60 * 1000);
+  const snap = await db.collectionGroup('messages')
+    .where('status', '==', 'received')
+    .where('created_at', '<', cutoff)
+    .limit(100)
+    .get();
+
+  const tasks = snap.docs.map((doc) => {
+    const sessionRef = doc.ref.parent.parent; // sessions/{sessionId}
+    const userRef = sessionRef.parent.parent; // chats/{userId}
+    const payload = {
+      docPath: doc.ref.path,
+      userId: userRef.id,
+      sessionId: sessionRef.id,
+      messageId: doc.id,
+      client_msg_id: doc.get('client_msg_id') || null
+    };
+    return pubsub.topic(TOPIC).publishMessage({ json: payload });
+  });
+
+  await Promise.all(tasks);
+});
+
+export default requeueStuckChatMessages;


### PR DESCRIPTION
## Summary
- add HTTP sendMessage handler for chat message queuing
- process chat messages via Pub/Sub worker with session locking
- requeue stuck chat messages on schedule

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a511a2c68c83228b64f642099876e8