### PR TITLE
Implement chat message processing with lock and search routing

### DIFF
--- a/functions/triggers/processChatMessage.js
+++ b/functions/triggers/processChatMessage.js
@@ -1,46 +1,82 @@
 import { onMessagePublished } from 'firebase-functions/v2/pubsub';
 import { db } from '../firebase/admin.js';
 import admin from 'firebase-admin';
+import { classifyChatSearchIntention } from '../utilities/openAi.js';
+import { searchInAlgolia } from '../utilities/algolia.js';
+import ragChunksFlow from '../genkit/flows/ragChunksFlow.js';
+
+const LOCK_TTL_MS = 60 * 1000;
+const MESSAGE_HISTORY_LIMIT = 10;
 
 const processChatMessage = onMessagePublished('chat-messages', async (event) => {
   const payload = event.data.message.json || {};
-  const { docPath, userId, sessionId } = payload;
+  const { docPath, userId, sessionId, client_msg_id } = payload;
   const workerId = event.id;
 
   const sessionRef = db.collection('chats').doc(userId).collection('sessions').doc(sessionId);
+  const lockRef = sessionRef.collection('locks').doc('chat');
   const messageRef = db.doc(docPath);
 
   try {
+    // Acquire lock for this session
     await db.runTransaction(async (tx) => {
-      const sessionSnap = await tx.get(sessionRef);
-      const lock = sessionSnap.get('lock');
+      const lockSnap = await tx.get(lockRef);
       const now = Date.now();
-      const leaseUntil = lock && lock.lease_until && lock.lease_until.toMillis ? lock.lease_until.toMillis() : 0;
+      const leaseUntil = lockSnap.exists && lockSnap.get('lease_until') && lockSnap.get('lease_until').toMillis ? lockSnap.get('lease_until').toMillis() : 0;
       if (leaseUntil > now) {
         throw new Error('locked');
       }
-      tx.set(sessionRef, {
-        lock: {
-          leased_by: workerId,
-          lease_until: admin.firestore.Timestamp.fromMillis(now + 60000)
-        }
-      }, { merge: true });
+      tx.set(lockRef, {
+        leased_by: workerId,
+        lease_until: admin.firestore.Timestamp.fromMillis(now + LOCK_TTL_MS)
+      });
     });
 
-    await messageRef.update({ status: 'processing' });
+    // Idempotency check
+    if (client_msg_id) {
+      const dupSnap = await sessionRef.collection('messages').where('client_msg_id', '==', client_msg_id).get();
+      if (!dupSnap.empty) {
+        await messageRef.set({ status: 'duplicate' }, { merge: true });
+        return;
+      }
+      await messageRef.set({ client_msg_id }, { merge: true });
+    }
+
+    await messageRef.set({ status: 'processing' }, { merge: true });
+
+    // Retrieve last N messages
+    const snap = await sessionRef.collection('messages')
+      .orderBy('timestamp', 'desc')
+      .limit(MESSAGE_HISTORY_LIMIT)
+      .get();
+    const messages = snap.docs.reverse().map((d) => ({
+      role: d.get('role'),
+      content: d.get('content'),
+      fullRes: d.get('fullResponse') || d.get('content')
+    }));
+
+    const userQuery = messages[messages.length - 1]?.content || '';
+
+    const { fullResponse, intention } = await classifyChatSearchIntention(messages);
+    let assistantContent = fullResponse;
+    if (intention === 'product_search') {
+      assistantContent = await searchInAlgolia(userQuery);
+    } else if (intention === 'document_search') {
+      const ragResp = await ragChunksFlow({ query: userQuery });
+      assistantContent = ragResp.answer;
+    }
 
     const assistantRef = sessionRef.collection('messages').doc();
     await assistantRef.set({
       role: 'assistant',
-      content: 'Mensaje procesado.',
+      content: assistantContent,
       created_at: admin.firestore.FieldValue.serverTimestamp(),
       status: 'done'
     });
 
-    await messageRef.update({ status: 'done' });
+    await messageRef.set({ status: 'done' }, { merge: true });
 
     await sessionRef.set({
-      lock: admin.firestore.FieldValue.delete(),
       last_message_at: admin.firestore.FieldValue.serverTimestamp()
     }, { merge: true });
 
@@ -51,7 +87,11 @@ const processChatMessage = onMessagePublished('chat-messages', async (event) => 
       error_message: err.message
     }, { merge: true });
     throw err; // make pub/sub retry
+  } finally {
+    // Release lock
+    await lockRef.delete().catch(() => {});
   }
 });
 
 export default processChatMessage;
+


### PR DESCRIPTION
## Summary
- Lock chat sessions via subcollection to avoid concurrent processing
- Add idempotency check for client messages and classify search intention
- Route to Algolia or RAG flow and store assistant responses

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b28a937fa88322b60b12fb7df6220f