### PR TITLE
Add intent-based routing funnel flow

### DIFF
--- a/functions/genkit/flows/routingFunnelFlow.js
+++ b/functions/genkit/flows/routingFunnelFlow.js
@@ -1,0 +1,174 @@
+import { z } from 'genkit';
+import { ai } from '../config.js';
+import { db } from '../../firebase/admin.js';
+import admin from 'firebase-admin';
+import { searchInAlgolia } from '../../utilities/algolia.js';
+import ragChunksFlow from './ragChunksFlow.js';
+import {
+  defaultRouterState,
+  extractBudgetFromText,
+  collectSpecifiedTraits,
+  assessPerceivedIntent,
+} from '../../utilities/routingFunnel.js';
+
+const routingFunnelFlow = ai.defineFlow(
+  {
+    name: 'routingFunnelFlow',
+    inputSchema: z.object({
+      userId: z.string(),
+      sessionId: z.string(),
+    }),
+    outputSchema: z.object({
+      outcome: z.enum(['needs_info', 'direct_search', 'advisory_answer']),
+      intent: z.string().optional(),
+      question: z.string().optional(),
+      content: z.any().optional(),
+    }),
+  },
+  async ({ userId, sessionId }) => {
+  try {
+    const sessionRef = db
+      .collection('chats')
+      .doc(userId)
+      .collection('sessions')
+      .doc(sessionId);
+
+    const messagesSnap = await sessionRef
+      .collection('messages')
+      .orderBy('created_at', 'asc')
+      .limitToLast(8)
+      .get();
+    const messages = messagesSnap.docs.map((d) => d.data());
+    const userQuery = messages[messages.length - 1]?.content || '';
+
+    const sessionDoc = await sessionRef.get();
+    let data = sessionDoc.exists ? sessionDoc.data() : {};
+    let router_state = data.router_state || defaultRouterState();
+    let awaiting_info = data.awaiting_info || false;
+    let awaiting_info_field = data.awaiting_info_field || null;
+
+    if (awaiting_info && awaiting_info_field) {
+      if (awaiting_info_field === 'purpose') {
+        router_state.advisory.purpose = userQuery.trim();
+      } else if (awaiting_info_field.startsWith('budget')) {
+        const b = extractBudgetFromText(userQuery);
+        if (b.budget_min != null) router_state.advisory.budget_min = b.budget_min;
+        if (b.budget_max != null) router_state.advisory.budget_max = b.budget_max;
+      }
+      awaiting_info = false;
+      awaiting_info_field = null;
+    }
+
+    const traits = collectSpecifiedTraits(messages);
+    router_state.direct.specified_traits = Array.from(
+      new Set([...(router_state.direct.specified_traits || []), ...traits])
+    );
+
+    const intentRes = await assessPerceivedIntent(messages);
+    router_state.intent = intentRes.intent;
+
+    if (router_state.intent === 'direct_search') {
+      const query = [userQuery, ...(router_state.direct.specified_traits || [])]
+        .join(' ')
+        .trim();
+      const filters = router_state.direct.hard_filters || {};
+      const content = await searchInAlgolia(query, filters);
+      await sessionRef.set(
+        {
+          router_state,
+          awaiting_info,
+          awaiting_info_field,
+          last_message_at: admin.firestore.FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
+      return { outcome: 'direct_search', content };
+    }
+
+    const missing = [];
+    if (!router_state.advisory.purpose) missing.push('purpose');
+    if (
+      router_state.advisory.budget_min == null &&
+      router_state.advisory.budget_max == null
+    ) {
+      missing.push('budget_min');
+      missing.push('budget_max');
+    }
+    router_state.missing = missing;
+
+    if (missing.length) {
+      const nextField = missing[0];
+      const question =
+        nextField === 'purpose'
+          ? '¿Para qué lo necesitas principalmente? (por ejemplo: ciudad diaria, familia, trabajo, viajes largos, off-road)'
+          : '¿Cuál es tu presupuesto aproximado? (puede ser un rango en COP)';
+      awaiting_info = true;
+      awaiting_info_field = nextField;
+      await sessionRef.set(
+        {
+          router_state,
+          awaiting_info,
+          awaiting_info_field,
+          last_message_at: admin.firestore.FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
+      return { outcome: 'needs_info', intent: 'advisory', question };
+    }
+
+    const {
+      purpose,
+      constraints,
+      brand_pref,
+      category_hint,
+      budget_min,
+      budget_max,
+    } = router_state.advisory;
+    const parts = [];
+    if (purpose) parts.push(purpose);
+    if (constraints && constraints.length) parts.push(constraints.join(', '));
+    if (brand_pref) parts.push(`marca ${brand_pref}`);
+    if (category_hint) parts.push(category_hint);
+    if (budget_min != null || budget_max != null) {
+      const b = [];
+      if (budget_min != null) b.push(`desde ${budget_min}`);
+      if (budget_max != null) b.push(`hasta ${budget_max}`);
+      parts.push(`presupuesto ${b.join(' ')}`.trim());
+    }
+    const semanticQuery = parts.join(', ');
+
+    const ragResp = await ragChunksFlow({
+      query: semanticQuery,
+      scope: 'products',
+      timebox: null,
+      strict_citation: false,
+    });
+
+    await sessionRef.set(
+      {
+        router_state,
+        awaiting_info,
+        awaiting_info_field,
+        last_message_at: admin.firestore.FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+
+    if (!ragResp || !ragResp.answer) {
+      return {
+        outcome: 'needs_info',
+        intent: 'advisory',
+        question:
+          'No encontré contexto suficiente. ¿Quieres ajustar el propósito de uso o el rango de presupuesto?',
+      };
+    }
+
+    return { outcome: 'advisory_answer', content: ragResp.answer };
+  } catch (error) {
+    console.error('routingFunnelFlow error', error);
+    throw error;
+  }
+});
+
+export default routingFunnelFlow;
+

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,6 +11,7 @@
         "@genkit-ai/dotprompt": "^0.9.12",
         "@genkit-ai/express": "^1.15.5",
         "@genkit-ai/firebase": "^1.13.0",
+        "@genkit-ai/flow": "^0.5.17",
         "@genkit-ai/google-cloud": "^1.15.5",
         "@genkit-ai/googleai": "^1.12.0",
         "@genkit-ai/vertexai": "^1.15.5",
@@ -2375,6 +2376,46 @@
         "firebase": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@genkit-ai/flow": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/flow/-/flow-0.5.17.tgz",
+      "integrity": "sha512-+P2VGfa5z2e9VzjAJysLAw0oHuPv02UEj/z4Csxuurv2xgL3CQCZ9DV81i+14/ybp5LJ8waPSFsrJ29ffQCPwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@genkit-ai/core": "0.5.17",
+        "@google-cloud/firestore": "^7.6.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/cors": "^2.8.17",
+        "body-parser": "^1.20.3",
+        "cors": "^2.8.5",
+        "express": "^4.21.0",
+        "firebase-admin": ">=12.2",
+        "firebase-functions": ">=4.8",
+        "uuid": "^9.0.1",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@genkit-ai/flow/node_modules/@genkit-ai/core": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-0.5.17.tgz",
+      "integrity": "sha512-o8aEIFjQ4FugS5w5XK1c6hmiX6bqx7u+UuikARJPMhqOek7aovcXXdYj2zbVmX2/4c94aXerSokB0vD59Pj3GQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.25.0",
+        "@opentelemetry/core": "^1.25.0",
+        "@opentelemetry/sdk-metrics": "^1.25.0",
+        "@opentelemetry/sdk-node": "^0.52.0",
+        "@opentelemetry/sdk-trace-base": "^1.25.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "async-mutex": "^0.5.0",
+        "express": "^4.21.0",
+        "json-schema": "^0.4.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.4"
       }
     },
     "node_modules/@genkit-ai/google-cloud": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -22,6 +22,7 @@
     "@genkit-ai/dotprompt": "^0.9.12",
     "@genkit-ai/express": "^1.15.5",
     "@genkit-ai/firebase": "^1.13.0",
+    "@genkit-ai/flow": "^0.5.17",
     "@genkit-ai/google-cloud": "^1.15.5",
     "@genkit-ai/googleai": "^1.12.0",
     "@genkit-ai/vertexai": "^1.15.5",

--- a/functions/utilities/routingFunnel.js
+++ b/functions/utilities/routingFunnel.js
@@ -1,0 +1,75 @@
+import { classifyChatSearchIntention } from './openAi.js';
+
+export function defaultRouterState() {
+  return {
+    intent: 'unknown',
+    advisory: {
+      purpose: null,
+      constraints: [],
+      budget_min: null,
+      budget_max: null,
+      brand_pref: null,
+      category_hint: null,
+    },
+    direct: {
+      specified_traits: [],
+      hard_filters: {},
+    },
+    missing: [],
+  };
+}
+
+export function extractBudgetFromText(text) {
+  const numbers = (text.match(/\d+[\d\.\,]*/g) || [])
+    .map((n) => parseFloat(n.replace(/\./g, '').replace(/\,/g, '.')))
+    .filter((n) => !isNaN(n));
+  if (!numbers.length) return { budget_min: null, budget_max: null };
+  if (numbers.length === 1) {
+    const isMax = /hasta|maximo|tope|máximo/i.test(text);
+    return {
+      budget_min: isMax ? null : numbers[0],
+      budget_max: isMax ? numbers[0] : null,
+    };
+  }
+  numbers.sort((a, b) => a - b);
+  return { budget_min: numbers[0], budget_max: numbers[numbers.length - 1] };
+}
+
+function isDecisiveLanguage(text) {
+  return /(necesito|debo|tiene que|requiero|quiero|comp[aá]rame|busco)/i.test(text);
+}
+
+export function collectSpecifiedTraits(messages) {
+  const traits = [];
+  const last = messages[messages.length - 1];
+  if (!last) return traits;
+  const regex = /"([^\"]+)"/g;
+  let m;
+  while ((m = regex.exec(last.content))) {
+    traits.push(m[1]);
+  }
+  return traits;
+}
+
+export async function assessPerceivedIntent(messages) {
+  const last = messages[messages.length - 1]?.content || '';
+  const prev = messages[messages.length - 2]?.content || '';
+  const combined = `${prev} ${last}`.trim();
+  let confidence = 0;
+  const budget = extractBudgetFromText(combined);
+  if (budget.budget_min != null || budget.budget_max != null) confidence += 0.2;
+  const constraints = (last.match(/,| y | con /gi) || []).length;
+  if (constraints >= 2) confidence += 0.3;
+  if (isDecisiveLanguage(combined)) confidence += 0.3;
+  try {
+    const cls = await classifyChatSearchIntention(messages);
+    if (cls?.intention === 'product_search') confidence += 0.1;
+    if (cls?.intention === 'document_search') confidence -= 0.1;
+  } catch {
+    // ignore errors
+  }
+  confidence = Math.max(0, Math.min(1, confidence));
+  const intent = confidence >= 0.6 ? 'direct_search' : 'advisory';
+  return { intent, confidence };
+}
+


### PR DESCRIPTION
## Summary
- implement `routingFunnelFlow` using Genkit `ai.defineFlow`
- move budget, trait, and intent helpers into shared utility module
- process chat trigger delegates message handling to `routingFunnelFlow`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b628b2c35c832293336f065bdb823c