### PR TITLE
feat: switch embeddings to openai

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,13 @@
+# Functions
+
+## Environment variables
+
+- `OPENAI_API_KEY`: API key used by the OpenAI plugin.
+- `EMBED_BATCH_SIZE`: Number of texts processed per batch (default `16`).
+- `EMBED_QPM`: Shared quota of embedding requests per minute (default `60`).
+- `EMBED_CONCURRENCY`: Parallel batches allowed (default `1`).
+- `EMBED_RETRIES`: Maximum retries for 429 responses (default `5`).
+
+The embedding batcher stores the global quota in the Firestore document
+`embeddingQuota/global`, with the fields `tokens` and `updatedAt` refreshed
+once per minute.

--- a/functions/genkit/config.js
+++ b/functions/genkit/config.js
@@ -1,5 +1,5 @@
 import { genkit } from 'genkit';
-import { vertexAI, gemini20Flash001, textEmbedding004 } from '@genkit-ai/vertexai';
+import { openAI } from '@genkit-ai/compat-oai/openai';
 import { devLocalVectorstore } from '@genkit-ai/dev-local-vectorstore';
 import { enableGoogleCloudTelemetry } from '@genkit-ai/google-cloud';
 import { logger } from 'genkit/logging';
@@ -19,17 +19,15 @@ export const ai = genkit({
   // 👇 apaga el Reflection Server aquí
   reflection: reflectionEnabled, // ← pon 'false' si quieres matar cualquier duda
   plugins: [
-    vertexAI({ location: 'us-central1' }),
+    openAI(),
     devLocalVectorstore([
       {
         indexName: 'product-items',
-        embedder: textEmbedding004,
-        embedderOptions: { taskType: 'RETRIEVAL_DOCUMENT' },
+        embedder: openAI.embedder('text-embedding-3-small'),
       },
       {
         indexName: 'chunks_embeddings',
-        embedder: textEmbedding004,
-        embedderOptions: { taskType: 'RETRIEVAL_DOCUMENT' },
+        embedder: openAI.embedder('text-embedding-3-small'),
       },
     ]),
   ],

--- a/functions/genkit/flows/embedChunkFlow.js
+++ b/functions/genkit/flows/embedChunkFlow.js
@@ -1,6 +1,6 @@
 import { z } from 'genkit';
 import { ai } from '../config.js';
-import { embedText } from '../../utilities/vertexEmbeddingBatcher.js';
+import { embedText } from '../../utilities/openAiEmbeddingBatcher.js';
 
 const embedChunkFlow = ai.defineFlow(
   {
@@ -13,7 +13,7 @@ const embedChunkFlow = ai.defineFlow(
   },
   async (content) => {
     const embedding = await embedText(content);
-    return { embedding, model: 'text-embedding-004' };
+    return { embedding, model: 'text-embedding-3-small' };
   }
 );
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "functions",
       "dependencies": {
+        "@genkit-ai/compat-oai": "^1.19.2",
         "@genkit-ai/core": "^1.12.0",
         "@genkit-ai/dev-local-vectorstore": "^1.15.5",
         "@genkit-ai/dotprompt": "^0.9.12",
@@ -2184,11 +2185,12 @@
       }
     },
     "node_modules/@genkit-ai/ai": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/ai/-/ai-1.15.5.tgz",
-      "integrity": "sha512-s/XwQS/cCHKmjBdEfoKXBw9T0RLd4jm1CVn19IE5ol20ElyL3A63uYjJwIXXjnjtpad+ZylMu38Of+T3MpPTfg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/ai/-/ai-1.19.2.tgz",
+      "integrity": "sha512-43H0XH0TQtXYuCgzbPp0Ao/gXE4VqAzRGF3nYqfH5xMCeHxdeGQthpMY90ng5JYxB618G1cPYVdjfwqYhs/Bqg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@genkit-ai/core": "1.15.5",
+        "@genkit-ai/core": "1.19.2",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.11.19",
         "colorette": "^2.0.20",
@@ -2201,9 +2203,10 @@
       }
     },
     "node_modules/@genkit-ai/ai/node_modules/@types/node": {
-      "version": "20.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
-      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
+      "version": "20.19.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.14.tgz",
+      "integrity": "sha512-gqiKWld3YIkmtrrg9zDvg9jfksZCcPywXVN7IauUGhilwGV/yOyeUsvpR796m/Jye0zUzMXPKe8Ct1B79A7N5Q==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2211,7 +2214,8 @@
     "node_modules/@genkit-ai/ai/node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@genkit-ai/ai/node_modules/uuid": {
       "version": "10.0.0",
@@ -2221,18 +2225,33 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@genkit-ai/compat-oai": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/compat-oai/-/compat-oai-1.19.2.tgz",
+      "integrity": "sha512-m2WY+QWtiDHMuEIlb6rELvw0d+scltgvUHqOccBEcTw8Ps4X26TqhJ41i90cC0ZxYySbAil2suWvqvk7cn2KXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "openai": "^4.95.0"
+      },
+      "peerDependencies": {
+        "genkit": "^1.19.2"
+      }
+    },
     "node_modules/@genkit-ai/core": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-1.15.5.tgz",
-      "integrity": "sha512-HVnN5/F/AtPxelCZNPVczn4WQUiGNVed17Trpdy51tjZFz9gmgWqgoG6p2+9gfDp0Uv0eN9Kq2cXWnJfJaGwHQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/core/-/core-1.19.2.tgz",
+      "integrity": "sha512-QkZRwCQSTQ+0M1ORj9DC/8GLIr7uWYPcubViGX3gtjRJ1QAI6PR4RHgkGipLI8jTQMYFLfJ9XoLPsTNUVz2+vw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "~1.25.0",
         "@opentelemetry/core": "~1.25.0",
+        "@opentelemetry/exporter-jaeger": "^1.25.0",
         "@opentelemetry/sdk-metrics": "~1.25.0",
         "@opentelemetry/sdk-node": "^0.52.0",
         "@opentelemetry/sdk-trace-base": "~1.25.0",
@@ -2248,6 +2267,9 @@
         "json-schema": "^0.4.0",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.22.4"
+      },
+      "optionalDependencies": {
+        "@genkit-ai/firebase": "^1.16.1"
       }
     },
     "node_modules/@genkit-ai/dev-local-vectorstore": {
@@ -2358,18 +2380,18 @@
       }
     },
     "node_modules/@genkit-ai/firebase": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/firebase/-/firebase-1.13.0.tgz",
-      "integrity": "sha512-FnbLiY713N1uHp7mwL78mNR+0os512KyOgBrvhuUJou7tKG7OAYzgr9pmPC4359fpDtSQdMYx7lXu4Oo1o16yQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/firebase/-/firebase-1.19.2.tgz",
+      "integrity": "sha512-HGHP3nGWqpfGxmbrYj2yyYz9z4de7KGWRNZ6AX4q95dtZyR778W+Nk7cOsRZT1v+BQQ9eugIyBVDnt72BIT9cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@genkit-ai/google-cloud": "^1.13.0"
+        "@genkit-ai/google-cloud": "^1.19.2"
       },
       "peerDependencies": {
         "@google-cloud/firestore": "^7.11.0",
         "firebase": ">=11.5.0",
         "firebase-admin": ">=12.2",
-        "genkit": "^1.13.0"
+        "genkit": "^1.19.2"
       },
       "peerDependenciesMeta": {
         "firebase": {
@@ -2378,9 +2400,10 @@
       }
     },
     "node_modules/@genkit-ai/google-cloud": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@genkit-ai/google-cloud/-/google-cloud-1.15.5.tgz",
-      "integrity": "sha512-CGqXeE48THyJL06r81/Nv03ri5xdKrTnUJQcsH7Tt09IPh4bJ7C1Js+QFJVwZJNxcrl/1eKhF2mb1tGZqQ+mng==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@genkit-ai/google-cloud/-/google-cloud-1.19.2.tgz",
+      "integrity": "sha512-nvU/6xViFSkrDJ4HFmv+/S9zXat/YEnovWDBs2CNoIo66MYiK8tgZ7z8poLOif+9PaesvBqdcJQxzvQD/uftZg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/logging-winston": "^6.0.0",
         "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.19.0",
@@ -2401,7 +2424,7 @@
         "winston": "^3.12.0"
       },
       "peerDependencies": {
-        "genkit": "^1.15.5"
+        "genkit": "^1.19.2"
       }
     },
     "node_modules/@genkit-ai/googleai": {
@@ -4161,6 +4184,81 @@
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
       "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-jaeger": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.30.1.tgz",
+      "integrity": "sha512-7Ki+x7cZ/PEQxp3UyB+CWkWBqLk22yRGQ4AWIGwZlEs6rpCOdWwIFOyQDO9DdeyWtTPTvO3An/7chPZcRHOgzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/sdk-trace-base": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0",
+        "jaeger-client": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -7078,6 +7176,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/ansi-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-color/-/ansi-color-0.2.1.tgz",
+      "integrity": "sha512-bF6xLaZBLpOQzgYUtYEhJx090nPSZk1BQ/q2oyBK9aMMcJHzx9uXGCjI2Y+LebsN4Jwoykr0V9whbPiogdyHoQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -7662,6 +7768,20 @@
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
       "license": "MIT"
+    },
+    "node_modules/bufrw": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/bufrw/-/bufrw-1.4.0.tgz",
+      "integrity": "sha512-sWm8iPbqvL9+5SiYxXH73UOkyEbGQg7kyHQmReF89WJHQJw2eV4P/yZ0E+b71cczJ4pPobVhXxgQcmfSTgGHxQ==",
+      "dependencies": {
+        "ansi-color": "^0.2.1",
+        "error": "^7.0.0",
+        "hexer": "^1.5.0",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.x"
+      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -8864,6 +8984,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/error": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+      "integrity": "sha512-UtVv4l5MhijsYUxPJo4390gzfZvAnTHreNnDjnTZaKIiZ/SemXxAhBkYSKtWa5RtBXbLP8tMgn/n0RUa/H7jXw==",
+      "dependencies": {
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -9981,12 +10110,13 @@
       }
     },
     "node_modules/genkit": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/genkit/-/genkit-1.15.5.tgz",
-      "integrity": "sha512-D4YdwMqbEpVvkymkr4oEwH/xOfLtQtfIalZZTfsYGM/drO6DvhMD5JzDpoN1GqWogRsyqQzU3KI5wK/miW3svg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/genkit/-/genkit-1.19.2.tgz",
+      "integrity": "sha512-GLTMqAzq8Dw7ECW9m1sqtcM4Y6lVLLQmu5UnZ7wkIR9Sj6iRmmjOV/IJcVluMDqnJ1BdiCTB7DmMxTxmO7ndrw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@genkit-ai/ai": "1.15.5",
-        "@genkit-ai/core": "1.15.5",
+        "@genkit-ai/ai": "1.19.2",
+        "@genkit-ai/core": "1.19.2",
         "uuid": "^10.0.0"
       }
     },
@@ -10408,6 +10538,31 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/hexer": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hexer/-/hexer-1.5.0.tgz",
+      "integrity": "sha512-dyrPC8KzBzUJ19QTIo1gXNqIISRXQ0NwteW6OeQHRN4ZuZeHkdODfj0zHBdOlHbRY8GqbqK57C9oWSvQZizFsg==",
+      "dependencies": {
+        "ansi-color": "^0.2.1",
+        "minimist": "^1.1.0",
+        "process": "^0.10.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "hexer": "cli.js"
+      },
+      "engines": {
+        "node": ">= 0.10.x"
+      }
+    },
+    "node_modules/hexer/node_modules/process": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
+      "integrity": "sha512-dyIett8dgGIZ/TXKUzeYExt7WA6ldDzys9vTDU/cCA9L17Ypme+KzS+NjQCjpn9xsvi/shbMC+yP/BcFMBz0NA==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -11096,6 +11251,31 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jaeger-client": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/jaeger-client/-/jaeger-client-3.19.0.tgz",
+      "integrity": "sha512-M0c7cKHmdyEUtjemnJyx/y9uX16XHocL46yQvyqDlPdvAcwPDbHrIbKjQdBqtiE4apQ/9dmr+ZLJYYPGnurgpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0",
+        "opentracing": "^0.14.4",
+        "thriftrw": "^3.5.0",
+        "uuid": "^8.3.2",
+        "xorshift": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jaeger-client/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/jest": {
@@ -13003,9 +13183,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -13283,6 +13461,15 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/opentracing": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
+      "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/optionator": {
@@ -15066,6 +15253,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw=="
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -15415,6 +15607,31 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/thriftrw": {
+      "version": "3.11.4",
+      "resolved": "https://registry.npmjs.org/thriftrw/-/thriftrw-3.11.4.tgz",
+      "integrity": "sha512-UcuBd3eanB3T10nXWRRMwfwoaC6VMk7qe3/5YIWP2Jtw+EbHqJ0p1/K3x8ixiR5dozKSSfcg1W+0e33G1Di3XA==",
+      "dependencies": {
+        "bufrw": "^1.2.1",
+        "error": "7.0.2",
+        "long": "^2.4.0"
+      },
+      "bin": {
+        "thrift2json": "thrift2json.js"
+      },
+      "engines": {
+        "node": ">= 0.10.x"
+      }
+    },
+    "node_modules/thriftrw/node_modules/long": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
+      "integrity": "sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -15684,7 +15901,8 @@
     "node_modules/uri-templates": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
-      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg=="
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
     },
     "node_modules/url-join": {
       "version": "4.0.1",
@@ -16181,6 +16399,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/xorshift": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-1.2.0.tgz",
+      "integrity": "sha512-iYgNnGyeeJ4t6U11NpA/QiKy+PXn5Aa3Azg5qkwIFz1tBLllQrjjsk9yzD7IAK0naNU4JxdeDgqW9ov4u/hc4g==",
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -23,6 +23,7 @@
     "@genkit-ai/express": "^1.15.5",
     "@genkit-ai/firebase": "^1.13.0",
     "@genkit-ai/google-cloud": "^1.15.5",
+    "@genkit-ai/compat-oai": "^1.19.2",
     "@genkit-ai/googleai": "^1.12.0",
     "@genkit-ai/vertexai": "^1.15.5",
     "@google-cloud/firestore": "^7.11.0",

--- a/functions/utilities/openAiEmbeddingBatcher.js
+++ b/functions/utilities/openAiEmbeddingBatcher.js
@@ -1,5 +1,8 @@
 import { ai } from '../genkit/config.js';
-import { textEmbedding004 } from '@genkit-ai/vertexai';
+import { openAI } from '@genkit-ai/compat-oai/openai';
+import { db } from '../firebase/admin.js';
+
+const openAiEmbedder = openAI.embedder('text-embedding-3-small');
 
 const BATCH_SIZE = parseInt(process.env.EMBED_BATCH_SIZE ?? '16', 10);
 const QPM = parseInt(process.env.EMBED_QPM ?? '60', 10);
@@ -10,14 +13,9 @@ const FLUSH_INTERVAL = 1000; // milliseconds
 
 const queue = [];
 let active = 0;
-let tokens = QPM;
 let timer = null;
-
-// Refill the token bucket every minute
-setInterval(() => {
-  tokens = QPM;
-  processQueue();
-}, 60 * 1000);
+let quotaBackoff = 0;
+const quotaRef = db.collection('embeddingQuota').doc('global');
 
 function scheduleFlush() {
   if (!timer) {
@@ -28,24 +26,50 @@ function scheduleFlush() {
   }
 }
 
+async function tryConsumeToken() {
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(quotaRef);
+    const now = Date.now();
+    let data = snap.exists ? snap.data() : { tokens: QPM, updatedAt: now };
+    if (now - (data.updatedAt || 0) >= 60 * 1000) {
+      data.tokens = QPM;
+      data.updatedAt = now;
+    }
+    if (data.tokens <= 0) {
+      tx.set(quotaRef, data);
+      return false;
+    }
+    data.tokens -= 1;
+    tx.set(quotaRef, data);
+    return true;
+  });
+}
+
 async function processQueue() {
   if (active >= CONCURRENCY) return;
   if (!queue.length) return;
-  if (tokens <= 0) {
-    scheduleFlush();
+
+  const hasToken = await tryConsumeToken();
+  if (!hasToken) {
+    const delay = BASE_DELAY * Math.pow(2, quotaBackoff) + Math.random() * BASE_DELAY;
+    quotaBackoff = Math.min(quotaBackoff + 1, MAX_RETRIES);
+    setTimeout(processQueue, delay);
     return;
   }
+  quotaBackoff = 0;
 
   const batch = queue.splice(0, BATCH_SIZE);
   active++;
-  tokens--;
 
   const contents = batch.map((item) => item.content);
   let attempt = 0;
 
   while (true) {
     try {
-      const res = await ai.embedMany({ embedder: textEmbedding004, content: contents });
+      const res = await ai.embedMany({
+        embedder: openAiEmbedder,
+        content: contents,
+      });
       res.forEach((r, i) => batch[i].resolve(r.embedding));
       break;
     } catch (err) {


### PR DESCRIPTION
## Summary
- use OpenAI plugin and embedder in Genkit config
- replace Vertex embedding batcher with OpenAI variant using Firestore quota
- document new environment variables for embeddings

## Testing
- `npm test`
- `npm run lint`
- ⚠️ `OPENAI_API_KEY=dummy node -e "import('./genkit/flows/embedChunkFlow.js').then(async (m)=>{try{const r=await m.default('hola'); console.log(r);}catch(e){console.error(e.message);}});"` *(missing Firebase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c82a1180d4832294455adc94192e1c