### PR TITLE
Handle missing error message in chunk indexing trigger

### DIFF
--- a/functions/triggers/processChunkIndexing.js
+++ b/functions/triggers/processChunkIndexing.js
@@ -72,10 +72,11 @@ const processChunkIndexing = onDocumentUpdated('chunksEmbeddings/{chunkId}', asy
     await tracedIndex({ chunkId: event.params.chunkId });
   } catch (err) {
     console.error('[processChunkIndexing] error', err);
+    const errorText = err?.message ?? (typeof err === 'string' ? err : JSON.stringify(err));
     await afterSnap.ref.set(
       {
         vectorIndexStatus: 'error',
-        vectorIndexError: err.message,
+        vectorIndexError: errorText,
       },
       { merge: true },
     );


### PR DESCRIPTION
## Summary
- safeguard Firestore error logging by deriving a string fallback when err.message is unavailable
- write the derived error text to vectorIndexError while preserving console diagnostics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb1329365c83229e7c91e0640f9477