### PR TITLE
Add manual product ingestion route

### DIFF
--- a/functions/handlers/products/postProductManual.js
+++ b/functions/handlers/products/postProductManual.js
@@ -1,0 +1,183 @@
+import { traceable } from 'langsmith/traceable';
+
+import { ProductManualSchema } from '../../schemas/productManual.js';
+import { generateParagraphForProductWithLangChain } from '../../utilities/openAi.js';
+import { generateListOfKeyWordsOfProduct } from '../../utilities/textProcessing.js';
+import { addDataToFirestore } from '../../utilities/firestore.js';
+
+const exampleParagraph = `
+El Ford Escape del año 2023 es un vehículo SUV disponible en color Blue,
+White, Black. Está equipado con un motor de 1.5 litros, que funciona con
+Gasoline, generando 181 caballos de fuerza y 190 Nm de torque. Este modelo
+puede acelerar de 0 a 60 mph en 7.1 segundos, con una velocidad máxima de 130 mph
+y un rendimiento de combustible de 30 millas por galón. En cuanto a la seguridad,
+incluye ABS, Airbags, Ford Co-Pilot360, Rear View Camera. El interior cuenta con
+Cloth Seats, Keyless Entry, Power Windows, ofreciendo confort y tecnología, mientras
+que el exterior destaca por LED Headlights, 18-inch Alloy Wheels, aportando estilo y
+funcionalidad. Además, incluye características de entretenimiento como 8-inch Touchscreen Display.
+El precio del vehículo es de $27650, y tiene una calificación promedio de 4.6.
+`.trim();
+
+const ATTRIBUTE_LABELS = {
+  car_make: 'Marca del vehículo',
+  car_model: 'Modelo del vehículo',
+  description: 'Descripción',
+  year: 'Año',
+  body_type: 'Tipo de carrocería',
+  color_options: 'Opciones de color',
+  fuel_type: 'Tipo de combustible',
+  engine_size_l: 'Motor (L)',
+  horsepower: 'Caballos de fuerza',
+  torque_nm: 'Torque (Nm)',
+  transmission_type: 'Tipo de transmisión',
+  acceleration_0_60_mph: 'Aceleración 0 a 60 mph (s)',
+  top_speed_mph: 'Velocidad máxima (mph)',
+  mileage_mpg: 'Rendimiento de combustible (mpg)',
+  safety_features: 'Características de seguridad',
+  entertainment_features: 'Características de entretenimiento',
+  interior_features: 'Equipamiento interior',
+  exterior_features: 'Equipamiento exterior',
+  price: 'Precio (USD)',
+  customer_ratings: 'Calificación de clientes',
+  pics: 'Imágenes del producto',
+  pdf: 'Documentos PDF',
+  product_url: 'URL del producto',
+  notes_seller: 'Notas del vendedor',
+};
+
+const ARRAY_FIELDS_TO_JOIN = [
+  'color_options',
+  'safety_features',
+  'entertainment_features',
+  'interior_features',
+  'exterior_features',
+  'pics',
+  'pdf',
+];
+
+const buildAttributeDictionary = (product) => {
+  const dictionary = {};
+  Object.keys(product).forEach((key) => {
+    dictionary[key] = {
+      descripcion: ATTRIBUTE_LABELS[key] || key.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase()),
+    };
+  });
+  return dictionary;
+};
+
+const prepareProductForLlm = (product) => {
+  const formatted = { ...product };
+  ARRAY_FIELDS_TO_JOIN.forEach((field) => {
+    if (Array.isArray(formatted[field])) {
+      formatted[field] = formatted[field].join(', ');
+    }
+  });
+  return formatted;
+};
+
+export const postProductManual = async (req, res) => {
+  try {
+    if (!req.user || req.user.type !== 'seller') {
+      return res.status(403).send({
+        error: 'Permiso denegado: solo los vendedores pueden subir productos.',
+      });
+    }
+
+    const { sellerId, showRoomId } = req.params;
+    if (!sellerId || !showRoomId) {
+      return res.status(400).send({
+        error: 'sellerId y showRoomId son requeridos en la URL.',
+      });
+    }
+
+    const rawPayload = req.body?.product ?? req.body ?? {};
+    const payload = typeof rawPayload === 'object' && rawPayload !== null ? rawPayload : {};
+
+    const parseResult = ProductManualSchema.safeParse(payload);
+    if (!parseResult.success) {
+      return res.status(400).send({
+        error: 'Payload inválido',
+        details: parseResult.error.flatten(),
+      });
+    }
+
+    const product = parseResult.data;
+    const productForLlm = prepareProductForLlm(product);
+    const attributeDictionary = buildAttributeDictionary(productForLlm);
+    const productNameParts = [product.car_make, product.car_model].filter((value) => value);
+    const productName = productNameParts.join(' - ') || 'Producto';
+
+    const tracedGenerateParagraph = traceable(
+      generateParagraphForProductWithLangChain,
+      {
+        name: 'generateParagraphForProductWithLangChain',
+        run_type: 'llm',
+        extractInputs: (productData, name, descriptions, example) => ({
+          productData,
+          productName: name,
+          descriptions,
+          exampleParagraph: example,
+        }),
+        extractOutputs: (output) => output,
+        metadata: { sellerId, showRoomId },
+        tags: ['4. generate active paragraph'],
+      },
+    );
+
+    const { activeParagraph } = await tracedGenerateParagraph(
+      productForLlm,
+      productName,
+      attributeDictionary,
+      exampleParagraph,
+    );
+    product.activeParagraph = activeParagraph;
+
+    const tracedGenerateKeywords = traceable(
+      generateListOfKeyWordsOfProduct,
+      {
+        name: 'generateListOfKeyWordsOfProduct',
+        run_type: 'tool',
+        extractInputs: (paragraph) => ({ activeParagraph: paragraph }),
+        extractOutputs: (output) => output,
+        metadata: { sellerId, showRoomId },
+        tags: ['5. generate list of keywords'],
+      },
+    );
+
+    const { listOfKeyWords } = await tracedGenerateKeywords(product.activeParagraph);
+    product.keyWords = listOfKeyWords;
+
+    const optionsDB = {
+      data: [product],
+      collection: 'products',
+      extras: {
+        sellerId,
+        companyName: res.locals.companyData?.name,
+        coords: res.locals.coordsData,
+        showRoomId,
+      },
+    };
+
+    const tracedAddToFirestore = traceable(
+      addDataToFirestore,
+      {
+        name: 'addDataToFirestore',
+        run_type: 'tool',
+        extractInputs: (options) => ({ optionsDB: options }),
+        extractOutputs: (output) => output,
+        metadata: { sellerId, showRoomId },
+        tags: ['6. firestore save data'],
+      },
+    );
+
+    const { documentIds } = await tracedAddToFirestore(optionsDB);
+
+    return res.status(200).send({
+      message: 'Producto subido y procesado correctamente.',
+      documentId: Array.isArray(documentIds) ? documentIds[0] : documentIds,
+    });
+  } catch (error) {
+    console.error('Error en postProductManual:', error);
+    return res.status(500).send({ error: 'Error interno del servidor.' });
+  }
+};

--- a/functions/index.js
+++ b/functions/index.js
@@ -35,6 +35,7 @@ import {
   docsPdf,
   docsHtml,
 } from './handlers/products/products.js';
+import { postProductManual } from './handlers/products/postProductManual.js';
 
 // buyers 
 import {
@@ -200,6 +201,8 @@ app.post(`/${apiVersion}/showroom/:showRoomId/seller/:sellerId/products/xlsx3`, 
 app.post(`/${apiVersion}/showroom/:showRoomId/seller/:sellerId/products/xlsx4`, firebaseAuth, coordsOfSellers, xlsx4);
 // 11-POST /products/xls5: Para agregar productos a través de un archivo xlsx y embeddings con trazabilidad LangSmith.
 app.post(`/${apiVersion}/showroom/:showRoomId/seller/:sellerId/products/xlsx5`, firebaseAuth, coordsOfSellers, xlsx5);
+// 11b-POST /products/manual: Para agregar un producto individual mediante JSON reutilizando el pipeline de xlsx5.
+app.post(`/${apiVersion}/sellers/:sellerId/showrooms/:showRoomId/products/manual`, firebaseAuth, coordsOfSellers, postProductManual);
 // 12-POST /products/:productId/docs: Para agregar documentos a un producto.
 app.post(`/${apiVersion}/showroom/:showRoomId/seller/:sellerId/product/:productId/docsPdf`, docsPdf);
 // 13-Test /testUrlPdf Para probar la creacion de los embeddings de un pdf

--- a/functions/schemas/productManual.js
+++ b/functions/schemas/productManual.js
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+const nonEmptyString = z.string().trim().min(1);
+const stringArray = z.array(nonEmptyString);
+const urlArray = z.array(z.string().trim().url());
+
+export const ProductManualSchema = z.object({
+  car_make: nonEmptyString,
+  car_model: nonEmptyString,
+  description: z.string().trim().optional(),
+  year: z.coerce.number().int().gte(1900).lte(2100),
+  body_type: nonEmptyString,
+
+  color_options: stringArray.optional(),
+  fuel_type: nonEmptyString,
+  engine_size_l: z.coerce.number().gte(0),
+  horsepower: z.coerce.number().int().gte(0),
+  torque_nm: z.coerce.number().int().gte(0),
+  transmission_type: nonEmptyString,
+
+  acceleration_0_60_mph: z.coerce.number().gte(0),
+  top_speed_mph: z.coerce.number().gte(0),
+  mileage_mpg: z.coerce.number().gte(0),
+
+  safety_features: stringArray.min(1),
+  entertainment_features: stringArray.optional(),
+  interior_features: stringArray.min(1),
+  exterior_features: stringArray.min(1),
+
+  price: z.coerce.number().gte(0),
+  customer_ratings: z.coerce.number().min(0).max(5).optional(),
+
+  pics: urlArray.optional(),
+  pdf: urlArray.optional(),
+  product_url: z.string().trim().url().optional(),
+  notes_seller: z.string().trim().optional(),
+});


### PR DESCRIPTION
## Summary
- add a JSON manual product handler that validates payloads, reuses the xlsx5 pipeline, and stores the result in Firestore
- introduce a Zod schema for manual product payloads and register the new handler under the products routes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc3050783c8322b74f59abff508307