### PR TITLE
Handle empty PDF text extraction

### DIFF
--- a/functions/handlers/products/products.js
+++ b/functions/handlers/products/products.js
@@ -5,7 +5,6 @@ import os from 'os';
 
 // 🧪 External libraries
 import Busboy from 'busboy';
-import pdfParse from 'pdf-parse';
 
 // 🧠 Langsmith
 import { traceable } from 'langsmith/traceable';
@@ -42,8 +41,9 @@ import {
 } from '../../utilities/embeddings.js';
 
 // External Docs
-import { 
-	convertExcelToCSV,  
+import {
+        convertExcelToCSV,
+        extractTextFromPdf,
 } from '../../utilities/externalDocs.js';
 
 // LLM
@@ -895,8 +895,10 @@ const docsPdf = async (req, res) => {
 		});
 		// Leer y procesar el PDF
 		const pdfBuffer = fs.readFileSync(filePath);
-		const pdfData = await pdfParse(pdfBuffer);
-		const pdfText = pdfData.text;
+                const pdfText = await extractTextFromPdf(pdfBuffer);
+                if (!pdfText) {
+                        throw new Error('No se pudo extraer texto del PDF proporcionado.');
+                }
 		// Generar embeddings desde OpenAI
 		const newEmbeddings = await getEmbeddingsFromOpenAI(pdfText);
 		// Ruta para guardar el archivo JSON

--- a/functions/utilities/externalDocs.js
+++ b/functions/utilities/externalDocs.js
@@ -69,7 +69,17 @@ const extractTextFromPdf = async (pdfBuffer) => {
     try {
         const data = await pdfParse(pdfBuffer);
         // data.text contiene el texto extraído de todas las páginas
-        return data.text ? data.text.replace(/\s+/g, ' ').trim() : null;
+        if (!data.text) {
+            return null;
+        }
+
+        const cleanedText = data.text.replace(/\s+/g, ' ').trim();
+
+        if (cleanedText.length === 0) {
+            return null;
+        }
+
+        return cleanedText;
     } catch (error) {
         console.error('Error extracting text from PDF:', error);
         return null;


### PR DESCRIPTION
## Summary
- ensure PDF text extraction returns null when the cleaned result is empty
- reuse the shared extractor in the product PDF upload handler and surface an error when no text is found

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1cd9806e4832299a48e0526f06822