### PR TITLE
Support Firebase Storage emulator in external doc downloads

### DIFF
--- a/functions/utilities/externalDocs.js
+++ b/functions/utilities/externalDocs.js
@@ -7,8 +7,9 @@ import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
 // pdf
 import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs';
-// xlsx 
+// xlsx
 import xlsx from 'xlsx'
+import { downloadFileBufferFromFirebaseUrl, parseFirebaseStorageUrl } from './cloudStorage.js';
 
 // convert excel to csv <---------
 const convertExcelToCSV = async (filepath) => {
@@ -40,6 +41,17 @@ const convertExcelToCSV = async (filepath) => {
 // para descargar y procesar docs desde urls
 const downloadDocFromExternalUrl = async (url) => {
   console.log("downloadDocFromExternalUrl");
+  const firebaseUrlInfo = parseFirebaseStorageUrl(url);
+  if (firebaseUrlInfo && process.env.FIREBASE_STORAGE_EMULATOR_HOST) {
+    const { buffer, contentType } = await downloadFileBufferFromFirebaseUrl(url, firebaseUrlInfo);
+
+    if (contentType !== 'application/pdf') {
+      throw new Error(`Invalid content-type. Expected application/pdf but received ${contentType}`);
+    }
+
+    return buffer;
+  }
+
   return new Promise((resolve, reject) => {
     https.get(url, (response) => {
       if (response.statusCode !== 200) {


### PR DESCRIPTION
## Summary
- add helpers in cloudStorage.js to parse Firebase Storage download URLs and stream them via the emulator when configured
- use the emulator-aware downloader in downloadDocFromExternalUrl while keeping the existing HTTPS path for other URLs

## Testing
- npm --prefix functions run lint

------
https://chatgpt.com/codex/tasks/task_e_68d30c2053908322a06fc7be060d4dbe