### PR TITLE
Handle multiple URL inputs for external doc downloads

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,7 @@
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
     "dev": "node index.js",
-    "test": "echo \"No tests specified\""
+    "test": "node --test"
   },
   "engines": {
     "node": "20"

--- a/functions/utilities/__tests__/externalDocs.test.js
+++ b/functions/utilities/__tests__/externalDocs.test.js
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {EventEmitter} from 'node:events';
+
+import {downloadDocFromExternalUrl} from '../externalDocs.js';
+
+const createHttpGetStub = () => {
+  let requestedUrl;
+
+  const httpGet = (url, handler) => {
+    requestedUrl = url;
+    const response = new EventEmitter();
+    response.statusCode = 200;
+    response.headers = { 'content-type': 'application/pdf' };
+
+    const requestEmitter = new EventEmitter();
+
+    setImmediate(() => {
+      handler(response);
+      response.emit('data', Buffer.from('TEST'));
+      response.emit('end');
+    });
+
+    return requestEmitter;
+  };
+
+  return {
+    httpGet,
+    getRequestedUrl: () => requestedUrl,
+  };
+};
+
+test('downloadDocFromExternalUrl trims string inputs', {concurrency: false}, async () => {
+  const {httpGet, getRequestedUrl} = createHttpGetStub();
+
+  const result = await downloadDocFromExternalUrl(' https://example.com/sample.pdf\t', {httpGet});
+
+  assert.ok(Buffer.isBuffer(result));
+  assert.strictEqual(result.toString(), 'TEST');
+  assert.strictEqual(getRequestedUrl(), 'https://example.com/sample.pdf');
+});
+
+test('downloadDocFromExternalUrl accepts URL objects', {concurrency: false}, async () => {
+  const {httpGet, getRequestedUrl} = createHttpGetStub();
+  const url = new URL('https://example.com/object.pdf');
+
+  await downloadDocFromExternalUrl(url, {httpGet});
+
+  assert.strictEqual(getRequestedUrl(), url.toString());
+});
+
+test('downloadDocFromExternalUrl warns and chooses first entry when multiple URLs are provided', {concurrency: false}, async (t) => {
+  const {httpGet, getRequestedUrl} = createHttpGetStub();
+  const originalWarn = console.warn;
+  let warnCalls = 0;
+  console.warn = () => {
+    warnCalls += 1;
+  };
+
+  t.after(() => {
+    console.warn = originalWarn;
+  });
+
+  await downloadDocFromExternalUrl([
+    'https://example.com/first.pdf',
+    'https://example.com/second.pdf',
+  ], {httpGet});
+
+  assert.strictEqual(getRequestedUrl(), 'https://example.com/first.pdf');
+  assert.strictEqual(warnCalls, 1);
+});
+


### PR DESCRIPTION
## Summary
- normalize `downloadDocFromExternalUrl` inputs to handle strings, URL objects, or arrays before running storage validation and downloading
- warn when multiple URLs are provided, fall back to the first entry, and allow tests to inject a custom HTTP client
- add Node test coverage for string, URL object, and array inputs and wire npm test to use the Node test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d33faf8d588322a9b470ce72976d1a