### PR TITLE
Limit manual product attribute fallbacks to seller data

### DIFF
--- a/docs/seller-data-dictionary.md
+++ b/docs/seller-data-dictionary.md
@@ -1,0 +1,85 @@
+# Seller Data Dictionary Flow
+
+This document explains how the seller data dictionary that is sent by the front-end is validated, persisted and later consumed by the manual product upload pipeline. The implementation was introduced in commit `Add seller data dictionary route and integration` and touches four main areas of the codebase.
+
+## 1. Validation schema (`functions/schemas/sellerDataDictionary.js`)
+
+*Purpose*: normalize the payload so each entry always exposes both `descripcion` and `description` strings.
+
+*Highlights*:
+- Accepts either a raw string or an object with `descripcion`/`description` properties for each field (for example `car_make`, `color_options`, etc.).
+- Trims the provided value and rejects empty strings to prevent persisting blank labels.
+- Normalizes the value by returning an object with both `descripcion` and `description` filled, which simplifies downstream consumption.
+
+```mermaid
+flowchart LR
+    A[Incoming value] -->|string| B{non-empty?}
+    B -->|yes| C[Return { descripcion, description }]
+    B -->|no| D[Validation error]
+    A -->|object| E{has descripcion or description?}
+    E -->|yes| C
+    E -->|no| D
+```
+
+## 2. Seller endpoint (`functions/handlers/sellers/sellers.js`)
+
+*Purpose*: allow an authenticated seller to persist the dictionary on their Firestore document.
+
+*Highlights*:
+- The handler `updateDataDictionary` looks for the payload either under `req.body.dataDictionary` or directly in the request body, which lets the client choose the wrapper format.
+- Handles the legacy `id_from_selller` typo by copying it into `id_from_seller` before validation so existing clients do not break.
+- Validates the payload with the schema above; if the schema rejects the request a `400` is returned with the validation details.
+- Resolves the seller document by `admin.userId == req.user.uid`, then merges the normalized dictionary under the `dataDictionary` field for every matching seller document.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API as /v1/sellers/dataDictionary
+    participant Firestore
+
+    Client->>API: POST { dataDictionary }
+    API->>API: Normalize & validate payload
+    alt valid
+        API->>Firestore: Query sellers by req.user.uid
+        Firestore-->>API: Seller snapshots
+        API->>Firestore: Merge { dataDictionary }
+        Firestore-->>API: Write ack
+        API-->>Client: 200 OK
+    else invalid
+        API-->>Client: 400 with errors
+    end
+```
+
+## 3. Middleware propagation (`functions/utilities/middlewares/coordsOfSellers.js`)
+
+*Purpose*: expose the seller dictionary to any downstream product route that relies on seller context.
+
+*Highlights*:
+- When the middleware fetches the seller document it now stores `sellerDoc.dataDictionary || {}` in `res.locals.dataDictionary`.
+- Product handlers (see next section) can read the dictionary from `res.locals` without needing another Firestore query.
+
+## 4. Manual product upload (`functions/handlers/products/postProductManual.js`)
+
+*Purpose*: reuse the seller dictionary when a manual product is uploaded so attribute labels remain consistent.
+
+*Highlights*:
+- `buildAttributeDictionary` walks each field present in the product, looks for a custom label inside `res.locals.dataDictionary`, and only falls back to a humanized version of the field name (e.g. `color_options` → `Color Options`) when the seller has not defined a value.
+- The resulting dictionary is persisted inside the product document (`product.attributeDictionary`) together with the generated copy (`product.activeParagraph`) and keywords.
+- Array fields like `color_options` or `pics` are joined into comma-separated strings before passing them to the LLM prompt so the language model receives a readable summary.
+
+```mermaid
+flowchart TD
+    A[Manual product payload] --> B[coordsOfSellers middleware]
+    B -->|res.locals.dataDictionary| C[buildAttributeDictionary]
+    C --> D[Merge seller labels with auto-generated fallbacks]
+    D --> E[Persist attributeDictionary on product]
+```
+
+## End-to-end data usage
+
+1. **Seller updates dictionary**: `POST /v1/sellers/dataDictionary` with the structure described in the user prompt.
+2. **Dictionary is stored**: The seller document gains/updates the `dataDictionary` field, containing normalized objects per attribute.
+3. **Manual product upload**: When calling `POST /v1/showroom/:showRoomId/seller/:sellerId/products/manual`, the middleware populates `res.locals.dataDictionary` with the seller’s stored values.
+4. **Product persistence**: The manual product handler merges the dictionary into the product payload so downstream consumers (UI, analytics, etc.) can render seller-specific labels consistently.
+
+This chain means that once a seller provides their preferred descriptions (e.g. localized explanations or internal naming) the manual product creation flow reuses them automatically without additional configuration.

--- a/functions/index.js
+++ b/functions/index.js
@@ -23,6 +23,7 @@ import coordsOfSellers from './utilities/middlewares/coordsOfSellers.js';
 import {
   sellers,
   coords,
+  updateDataDictionary,
 } from './handlers/sellers/sellers.js';
 
 // products
@@ -171,6 +172,7 @@ app.post(`/${apiVersion}/sellers`, firebaseAuth, sellers);
 // app.delete(`/${apiVersion}/sellers/:sellerId`, firebaseAuth, deleteSeller);
 // 6-POST /sellers/:sellerId/coords: Para agregar coordenadas a un vendedor.
 app.post(`/${apiVersion}/sellers/coords`, firebaseAuth, coords);
+app.post(`/${apiVersion}/sellers/dataDictionary`, firebaseAuth, updateDataDictionary);
 // // 7-POST /sellers/:sellerId/images/local360: Para agregar una imagen 360 del local en un vendedor.
 // app.post(`/${apiVersion}/sellers/:sellerId/images/local360`, firebaseAuth, localImage360);
 

--- a/functions/schemas/sellerDataDictionary.js
+++ b/functions/schemas/sellerDataDictionary.js
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+const dictionaryValueSchema = z
+  .union([
+    z.string().trim().min(1, 'La descripción no puede estar vacía.'),
+    z
+      .object({
+        descripcion: z.string().trim().min(1, 'La descripción no puede estar vacía.').optional(),
+        description: z.string().trim().min(1, 'La descripción no puede estar vacía.').optional(),
+      })
+      .refine(
+        (value) =>
+          (typeof value.descripcion === 'string' && value.descripcion.trim().length > 0) ||
+          (typeof value.description === 'string' && value.description.trim().length > 0),
+        {
+          message: 'Debe proporcionar al menos una descripción.',
+        },
+      ),
+  ])
+  .transform((value) => {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return { descripcion: trimmed, description: trimmed };
+    }
+
+    const descripcion = value.descripcion?.trim() ?? value.description?.trim() ?? '';
+    const description = value.description?.trim() ?? descripcion;
+
+    return { descripcion, description };
+  });
+
+export const SellerDataDictionarySchema = z
+  .record(dictionaryValueSchema)
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'El diccionario no puede estar vacío.',
+  });
+
+export default SellerDataDictionarySchema;

--- a/functions/utilities/middlewares/coordsOfSellers.js
+++ b/functions/utilities/middlewares/coordsOfSellers.js
@@ -17,14 +17,17 @@ const coordsOfSellers = async (req, res, next) => {
         }
 
         // Extract and pass data to the next middleware
+        const sellerDoc = doc.data();
         const sellerData = {
-            coords: doc.data().coords,
-            companyData: doc.data().companyData
+            coords: sellerDoc.coords,
+            companyData: sellerDoc.companyData,
+            dataDictionary: sellerDoc.dataDictionary || {}
 
         };
         console.log('sellerData: ', sellerData);
         res.locals.coordsData = sellerData.coords;
         res.locals.companyData = sellerData.companyData;
+        res.locals.dataDictionary = sellerData.dataDictionary;
         return next();
     } catch (err) {
         console.error('Error while fetching seller data: ', err);


### PR DESCRIPTION
## Summary
- stop sending hard-coded attribute descriptions with manual product uploads
- generate readable fallbacks from field names only when the seller has not provided a label
- update the seller dictionary documentation to describe the new fallback behaviour

## Testing
- npm --prefix functions test

------
https://chatgpt.com/codex/tasks/task_e_68e5a26e5fc483228c4ea387cc38167a